### PR TITLE
removed breaking news and outdated refs to profiles, formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # ro-crate-schema-tools
 
-
-This repository contains node-based tools for Research Object Crate [RO-Crate](https://www.researchobject.org/ro-crate/) to be used for creating and distributing Schema.org style ontologies (SOSSs) and Mode Files for configuring the [Crate-O editor](https://github.com/Language-Research-Technology/crate-o).
-
-# BREAKING NEWS -- We are changing the term "Profile" in the context of Crate-O to the term "Mode File" -- changes will be made in early 2024 in all the repositories but there may be some inconsistencies for a while
+This repository contains node-based tools for Research Object Crate ([RO-Crate](https://www.researchobject.org/ro-crate/)) to be used for creating and distributing Schema.org Style Schemas (SOSSs) and Mode Files for configuring the [Crate-O editor](https://github.com/Language-Research-Technology/crate-o).
 
 
 ## Background: What's a Schema.org Style Schema?
 
-Schema.org is available in schema.org [JSON-LD format](https://schema.org/version/latest/schemaorg-current-https.jsonld). 
+Schema.org is available in schema.org [JSON-LD format](https://schema.org/version/latest/schemaorg-current-https.jsonld).
 
 For example, `schema:Dataset` has the following definition:
 
@@ -38,29 +35,26 @@ For example, `schema:Dataset` has the following definition:
    }
 ```
 
-Note that while there is a `schema:Class` Class, but we follow Schema.org practice and use `rdfs:Class` and `rdf:Property` for describing classes and schemas.
+Note that while there is a `schema:Class` Class, we follow Schema.org practice and use `rdfs:Class` and `rdf:Property` for describing classes and schemas.
+
 
 ## About the tools
 
 These tools:
 
--  Create SOSS schemas from example RO-Crates
--  Create (and soon to incrementally update) RO-Crate Editor ~~profiles~~ Mode Files that can be used to drive editors such as Crate-O.
--  Produce static markdown and html documentation for SOSSs, you can put this on the web and use it to provide resolution to human-readable definitions of your linked data terms
- 
-
+-  Create SOSSs from example RO-Crates.
+-  Create (and soon, incrementally update) RO-Crate Editor Mode Files that can be used to drive editors such as Crate-O.
+-  Produce static markdown and HTML documentation for SOSSs. You can put this on the web and use it to provide resolution to human-readable definitions of your linked data terms.
 
 
 ## To generate documentation for a SOSS Crate
 
-To see the usage:
-
- -  type `>> node roc-schema.js  -h`
+To see the usage, type `>> node roc-schema.js  -h`
 
  ```
 Usage: roc-schema [options] <d>
 
-Extracts a markdown or HTML page from an RO Crate that containx Schema.org style Classes and Properties 
+Extracts a markdown or HTML page from an RO-Crate that contains Schema.org style Classes and Properties.
 
 Options:
   -V, --version            output the version number
@@ -73,27 +67,18 @@ Options:
 ```
 
 
-
 ## To generate or update a SOSS Crate from one or more examples
 
 The Makefile contains some examples.
 
-To make a generic RO-Crate Editor ~~Profile~~ Mode File:
+To make a generic RO-Crate Editor Mode File:
 
 ```make generic```
 
-To make a base ~~profile~~ Mode File that includes ALL of schema.org plus the RO-Crate add-ins:
+To make a base Mode File that includes ALL of schema.org plus the RO-Crate add-ins:
 
 ```make base```
 
-For usage
+For usage:
 
 ```rocsoss --help```
-
-
-
-
-
-
-
-

--- a/roc-schema.js
+++ b/roc-schema.js
@@ -12,7 +12,7 @@ var crateDir;
 program
   .version("0.1.0")
   .description(
-    "Extracts a markdown or HTML page from an RO Crate containing Schema.org style Classes and Properties "
+    "Extracts a markdown or HTML page from an RO-Crate containing Schema.org style Classes and Properties."
   )
   .arguments("<d>")
   .option("--html", "Output HTML (default is markdown)")


### PR DESCRIPTION
Changes made on the profile_mode_updates forked branch:
- Removed breaking news section
- Removed already struck-out references to profile that had been replaced with Mode
- Other formatting and typo fixes

Changes made to README file and one description line of roc-schema.js, but if any other changes are needed, let me know.